### PR TITLE
Update new_quest_lv7.quest

### DIFF
--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -1,6 +1,6 @@
 quest new_quest_lv7 begin
     state start begin
-    -- Function declaration
+        -- Function declaration
         function reward()
             local div = number(1,5)
             local reward = 5000
@@ -8,6 +8,7 @@ quest new_quest_lv7 begin
             reward = math.floor(reward/div)
             return reward
         end
+
         function reward_exp()
             local div = number(1,4)
             local reward_exp = 4000
@@ -16,29 +17,30 @@ quest new_quest_lv7 begin
             return reward_exp
         end
         -- end function declaration
+
         -- When level 7 target Octavio for new Quest-------------------------------------------------------------
         when login or levelup with pc.get_level() >= 7 begin
-            local v=find_npc_by_vnum(20008)
-            if 0==v then
+            local v = find_npc_by_vnum(20008)
+            if 0 == v then
             else
                 target.vid("__TARGET__", v, gameforge.new_quest_lv7._010_target)
             end
         end
-        
+
         when 20008.chat.gameforge.new_quest_lv7._020_say_title with pc.get_level() >= 7 begin
             target.delete("__TARGET__")
             local empire = pc.get_empire()
             say_title(gameforge.new_quest_lv7._011_say_title)  -- A Daughters Wedding
             say(gameforge.new_quest_lv7._021_say) -- Octavio has a daughter and she is in love with a guy for a village
-                if empire == 1 then -- = Shinsoo
-                    say(gameforge.new_quest_lv7._022_say) -- The guy lives in a village in the Jayang area
-                end
-                if empire == 2 then -- = Chunjo
-                    say(gameforge.new_quest_lv7._023_say) -- The guy lives in a village in the Bokjung area
-                end
-                if empire == 3 then -- = Jinno
-                    say(gameforge.new_quest_lv7._024_say) -- The guy lives in a village in the Bakra area
-                end
+            if empire == 1 then -- = Shinsoo
+                say(gameforge.new_quest_lv7._022_say) -- The guy lives in a village in the Jayang area
+            end
+            if empire == 2 then -- = Chunjo
+                say(gameforge.new_quest_lv7._023_say) -- The guy lives in a village in the Bokjung area
+            end
+            if empire == 3 then -- = Jinno
+                say(gameforge.new_quest_lv7._024_say) -- The guy lives in a village in the Bakra area
+            end
             wait() -- next button 
             say_title(gameforge.new_quest_lv7._011_say_title) -- A Daughters Wedding
             say(gameforge.new_quest_lv7._030_say) -- Octavio heared that she is going to marry him there
@@ -69,7 +71,7 @@ quest new_quest_lv7 begin
     state ask_oldwoman begin
         function get_old_woman_map() 
             local empire = pc.get_empire()
-            if empire == 1  then 
+            if empire == 1 then 
                 return 1 
             elseif empire == 2 then 
                 return 21
@@ -77,6 +79,7 @@ quest new_quest_lv7 begin
                 return 41
             end
         end
+
         function is_my_vil()
             if pc.get_map_index() == new_quest_lv7.get_old_woman_map() then
                 return true
@@ -97,14 +100,16 @@ quest new_quest_lv7 begin
             new_quest_lv7_drop1 = 30169 -- Blutrote Blume
             new_quest_lv7_drop2 = 30170 -- Orangefarbene Blume
             new_quest_lv7_drop3 = 30171 --  Duftende gelbe Blume
+
             -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No quest letter, no questbook entry
             send_letter(gameforge.new_quest_lv7._020_say_title)  -- A Daughters Wedding
             q.start()
             q.set_title(gameforge.new_quest_lv7._020_say_title) -- A Daughters Wedding
             -- END EDIT
+
             if new_quest_lv7.is_my_vil() then
-                local v=find_npc_by_vnum(9006) -- Old Lady
-                if 0==v then
+                local v = find_npc_by_vnum(9006) -- Old Lady
+                if 0 == v then
                 else
                     target.vid("__TARGET2__", v, gameforge.new_quest_lv7._040_target ) -- Old Lady
                 end
@@ -125,29 +130,29 @@ quest new_quest_lv7 begin
             target.delete("__TARGET2__")
             say_title(gameforge.new_quest_lv7._012_say_title) -- yellow text headline
             say(gameforge.new_quest_lv7._051_say)
-        wait()
+            wait()
             say_title(gameforge.new_quest_lv7._012_say_title) -- yellow text headline
             say(gameforge.new_quest_lv7._052_say)
             -- "vom Bräutigam an seine Liebste überreicht" versteht das unsere Zielgruppe?
-        wait()	
+            wait()	
             say(gameforge.new_quest_lv7._054_say)
             say_reward(string.format("%s x", new_quest_lv7_AmountNeed1))
             say_item_vnum(new_quest_lv7_drop1) -- icon of item
             say_reward(gameforge.new_quest_lv7._055_say)
             say(mob_name(new_quest_lv7_mob1))
-        wait()
+            wait()
             say(gameforge.new_quest_lv7._056_say)
             say_reward(string.format("%s x", new_quest_lv7_AmountNeed2))
             say_item_vnum(new_quest_lv7_drop2) -- icon of item
             say_reward(gameforge.new_quest_lv7._055_say)
             say(mob_name(new_quest_lv7_mob2))
-        wait()
+            wait()
             say(gameforge.new_quest_lv7._056_say)
             say_reward(string.format("%s x", new_quest_lv7_AmountNeed3))
             say_item_vnum(new_quest_lv7_drop3) -- icon of item
             say_reward(gameforge.new_quest_lv7._055_say )
             say(mob_name(new_quest_lv7_mob3))
-        wait()
+            wait()
             say_title(gameforge.new_quest_lv7._012_say_title)
             say(gameforge.new_quest_lv7._060_say)
             -- Wo ist die Schwester?
@@ -155,6 +160,7 @@ quest new_quest_lv7 begin
             set_state(collect_flowers)
         end
     end
+
     ----- collect flowers -------------------------------------------------------------------------------------------------
     state collect_flowers begin
         -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No letter, questbook entry, button						
@@ -174,8 +180,8 @@ quest new_quest_lv7 begin
             
             -- FIX: if the player already has all flowers, go directly to return_oldwoman
             if pc.count_item(new_quest_lv7_drop1) >= new_quest_lv7_AmountNeed1
-               and pc.count_item(new_quest_lv7_drop2) >= new_quest_lv7_AmountNeed2
-               and pc.count_item(new_quest_lv7_drop3) >= new_quest_lv7_AmountNeed3 then
+                and pc.count_item(new_quest_lv7_drop2) >= new_quest_lv7_AmountNeed2
+                and pc.count_item(new_quest_lv7_drop3) >= new_quest_lv7_AmountNeed3 then
                 q.done()
                 set_state(return_oldwoman)
                 return
@@ -188,25 +194,30 @@ quest new_quest_lv7 begin
         -- itemicon vnum of flower used for icon 
         function when_one_killed(neededAmount, dropProb, itemIcon)
             if pc.count_item(itemIcon) < neededAmount then
-        local drop=number(1,100)
+                local drop = number(1,100)
                 if drop <= dropProb then -- probability if s.th. drops
                     pc.give_item2(itemIcon) -- icon of item by vnum - Blutrote Blume
                     --  EDIT Arne 18Sept09 moved q.done    Reason: removed quest from book
                     -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No arrow on old lady for flower return	
                     --notice_multiline(gameforge.new_quest_lv7._088_notice, notice)
-                    if (pc.count_item(new_quest_lv7_drop3) == new_quest_lv7_AmountNeed3 and pc.count_item(new_quest_lv7_drop2) == new_quest_lv7_AmountNeed2 and pc.count_item(new_quest_lv7_drop1) == new_quest_lv7_AmountNeed1) then
-            return true
-            end
+                    if pc.count_item(new_quest_lv7_drop3) == new_quest_lv7_AmountNeed3
+                        and pc.count_item(new_quest_lv7_drop2) == new_quest_lv7_AmountNeed2
+                        and pc.count_item(new_quest_lv7_drop1) == new_quest_lv7_AmountNeed1 then
+                        return true
+                    end
                 else
-            --notice_multiline(gameforge.new_quest_lv7._082_say, notice)
-        end
+                    --notice_multiline(gameforge.new_quest_lv7._082_say, notice)
+                end
             end
 
             -- FIX: also check completion when there is no drop or flowers came from trade
-            if (pc.count_item(new_quest_lv7_drop3) >= new_quest_lv7_AmountNeed3 and pc.count_item(new_quest_lv7_drop2) >= new_quest_lv7_AmountNeed2 and pc.count_item(new_quest_lv7_drop1) >= new_quest_lv7_AmountNeed1) then
+            if pc.count_item(new_quest_lv7_drop3) >= new_quest_lv7_AmountNeed3
+                and pc.count_item(new_quest_lv7_drop2) >= new_quest_lv7_AmountNeed2
+                and pc.count_item(new_quest_lv7_drop1) >= new_quest_lv7_AmountNeed1 then
                 return true
             end
         end
+
         -------------- Blutrote Blume ------------------------------------------------------
         -- kill a 173#Hungriger Alpha-Wolf
         when 173.kill begin
@@ -215,14 +226,16 @@ quest new_quest_lv7 begin
                 set_state(return_oldwoman)
             end
         end
+
         -------------- Orangefarbene Blume ------------------------------------------------------
         -- kill a 174#Hungriger Blauwolf
         when 174.kill begin
             if new_quest_lv7.when_one_killed(new_quest_lv7_AmountNeed2, new_quest_lv7_dropProb2, new_quest_lv7_drop2) then 
                 q.done()
                 set_state(return_oldwoman)
-                        end
+            end
         end
+
         -------------- Duftende gelbe Blume ------------------------------------------------------
         -- kill a 175#Hungriger Alpha-Blauwolf
         when 175.kill begin		
@@ -238,23 +251,19 @@ quest new_quest_lv7 begin
             say_title(gameforge.new_quest_lv7._020_say_title)
             say(gameforge.new_quest_lv7._092_say) -- collect flowers for the Bouquet
             if pc.count_item(new_quest_lv7_drop1) < new_quest_lv7_AmountNeed1 then
-                say_reward(string.format(gameforge.new_quest_lv7._085_1_say_reward, new_quest_lv7_AmountNeed1 - 
-    pc.count_item(new_quest_lv7_drop1))) -- number of red flowers missing
+                say_reward(string.format(gameforge.new_quest_lv7._085_1_say_reward, new_quest_lv7_AmountNeed1 - pc.count_item(new_quest_lv7_drop1))) -- number of red flowers missing
             end
             if pc.count_item(new_quest_lv7_drop2) < new_quest_lv7_AmountNeed2 then
-                say_reward(string.format(gameforge.new_quest_lv7._085_2_say_reward, new_quest_lv7_AmountNeed2 - 
-    pc.count_item(new_quest_lv7_drop2))) -- number of orange flowers missing
+                say_reward(string.format(gameforge.new_quest_lv7._085_2_say_reward, new_quest_lv7_AmountNeed2 - pc.count_item(new_quest_lv7_drop2))) -- number of orange flowers missing
             end
             if pc.count_item(new_quest_lv7_drop3) < new_quest_lv7_AmountNeed3 then
-                say_reward(string.format(gameforge.new_quest_lv7._085_3_say_reward, new_quest_lv7_AmountNeed3 - 
-    pc.count_item(new_quest_lv7_drop3))) -- number of yellow flowers missing
+                say_reward(string.format(gameforge.new_quest_lv7._085_3_say_reward, new_quest_lv7_AmountNeed3 - pc.count_item(new_quest_lv7_drop3))) -- number of yellow flowers missing
             end
         end
     end
 
 
     state return_oldwoman begin -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, state needed to set up quest		
-
         when enter or login begin
             new_quest_lv7_AmountNeed1 = 1
             new_quest_lv7_AmountNeed2 = 1
@@ -262,13 +271,13 @@ quest new_quest_lv7 begin
             new_quest_lv7_drop1 = 30169 -- Blutrote Blume
             new_quest_lv7_drop2 = 30170 -- Orangefarbene Blume
             new_quest_lv7_drop3 = 30171 --  Duftende gelbe Blume
-            local v=find_npc_by_vnum(9006)
+            local v = find_npc_by_vnum(9006)
             send_letter(gameforge.new_quest_lv7._020_say_title)
             q.start()
             q.set_title(gameforge.new_quest_lv7._020_say_title)
-            if 0==v then
-                else
-                    target.vid("__TARGET6__", v, gameforge.new_quest_lv7._040_target)
+            if 0 == v then
+            else
+                target.vid("__TARGET6__", v, gameforge.new_quest_lv7._040_target)
             end
         end
         
@@ -279,13 +288,15 @@ quest new_quest_lv7 begin
             -- FIX: correct map name (same logic as in ask_oldwoman)
             say(string.format(gameforge.new_quest_lv7._042_say, get_map_name_by_number(new_quest_lv7.get_old_woman_map())))
         end
-    --END EDIT
+        --END EDIT
 
         -------------- try to give old woman the flowers ---------------------
         when 9006.chat.gameforge.new_quest_lv7._020_say_title begin
             target.delete("__TARGET6__")
             say_title(gameforge.new_quest_lv7._012_say_title)
-            if (pc.count_item(new_quest_lv7_drop1) < new_quest_lv7_AmountNeed1 or pc.count_item(new_quest_lv7_drop2) < new_quest_lv7_AmountNeed2 or pc.count_item(new_quest_lv7_drop3) < new_quest_lv7_AmountNeed3) then
+            if pc.count_item(new_quest_lv7_drop1) < new_quest_lv7_AmountNeed1
+                or pc.count_item(new_quest_lv7_drop2) < new_quest_lv7_AmountNeed2
+                or pc.count_item(new_quest_lv7_drop3) < new_quest_lv7_AmountNeed3 then
                 say(gameforge.new_quest_lv7._110_say)
                 -- FIX: avoid negative numbers if player has more flowers than needed
                 say_reward(string.format(gameforge.new_quest_lv7._085_say_reward, math.max(0, new_quest_lv7_AmountNeed1 - pc.count_item(new_quest_lv7_drop1))))
@@ -316,6 +327,7 @@ quest new_quest_lv7 begin
             end
         end
     end
+
     --- go to twin sister of old woman in other kingdom---------------------------------------------------------------------------------------------------
     state find_empire begin
         when login or enter begin
@@ -324,34 +336,36 @@ quest new_quest_lv7 begin
             q.start()
             q.set_title(gameforge.new_quest_lv7._020_say_title)
             -- END EDIT
+
             new_quest_lv7_DestMapIndex = 99
             if pc.get_empire() == 1 then -- = Shinsoo
                 new_quest_lv7_DestMapIndex = 3 -- = Yayang
-                local v=find_npc_by_vnum(10001)
-                if 0==v then
+                local v = find_npc_by_vnum(10001)
+                if 0 == v then
                 else
                     target.vid("__TARGET7__", v, gameforge.map_warp._190_select)
                 end
             elseif pc.get_empire() == 2 then -- = Chunjo
                 new_quest_lv7_DestMapIndex = 23 -- = Bokjung
-                local v=find_npc_by_vnum(10003)
-                if 0==v then
+                local v = find_npc_by_vnum(10003)
+                if 0 == v then
                 else
                     target.vid("__TARGET7__", v, gameforge.map_warp._210_select)
                 end
             elseif pc.get_empire() == 3 then -- = Jinno
                 new_quest_lv7_DestMapIndex = 43 -- = Bakra
-                local v=find_npc_by_vnum(10005)
-                if 0==v then
+                local v = find_npc_by_vnum(10005)
+                if 0 == v then
                 else
                     target.vid("__TARGET7__", v, gameforge.map_warp._230_select)
                 end
             end
+
             if pc.get_map_index() == new_quest_lv7_DestMapIndex  then
                 target.delete("__TARGET7__")
                 --notice_multiline(gameforge.new_quest_lv7._125_notice, notice)
-                local v=find_npc_by_vnum(9006)
-                if 0==v then
+                local v = find_npc_by_vnum(9006)
+                if 0 == v then
                 else
                     target.vid("__TARGET3__", v, gameforge.subquest_48._230_targetVid)
                 end
@@ -360,7 +374,6 @@ quest new_quest_lv7 begin
         end
         
         when button or info begin
-            
             say_title(gameforge.new_quest_lv7._020_say_title)
             say(gameforge.new_quest_lv7._131_say)
             if new_quest_lv7_DestMapIndex == 3 then 
@@ -372,6 +385,7 @@ quest new_quest_lv7 begin
             end
         end
     end
+
     ------  find the sister of the old woman in a different empire ------------------------------------------------------------------------------------------------------
     state goto_oldwomans_sister begin
         when enter or login begin
@@ -396,11 +410,11 @@ quest new_quest_lv7 begin
                 say_title(gameforge.new_quest_lv7._020_say_title) -- yellow
                 pc.remove_item(30172, pc.count_item(30172))
                 say_title(pc.get_name())
-                        say(gameforge.new_quest_lv7._140_say)
-                        say_title(gameforge.new_quest_lv7._012_say_title)
+                say(gameforge.new_quest_lv7._140_say)
+                say_title(gameforge.new_quest_lv7._012_say_title)
                 say(gameforge.new_quest_lv7._141_say)
                 wait()
-                        say_title(gameforge.new_quest_lv7._012_say_title)
+                say_title(gameforge.new_quest_lv7._012_say_title)
                 say(gameforge.new_quest_lv7._142_say)
                 q.done()
                 set_state(find_way_home)
@@ -413,11 +427,13 @@ quest new_quest_lv7 begin
                 set_state(ask_oldwoman)
             end
         end
+
         when button or info begin
             q.set_title(gameforge.new_quest_lv7._020_say_title)
             say(gameforge.new_quest_lv7._145_say)
         end
     end
+
     ------ return to first village ------------------------------------------------------------------------------------------------------
     state find_way_home begin
         when login or enter begin
@@ -429,22 +445,22 @@ quest new_quest_lv7 begin
             new_quest_lv7_HomeMapIndex = 99
             if pc.get_empire() == 1 then -- = Shinsoo
                 new_quest_lv7_HomeMapIndex = 1 -- = Youngan
-                local v=find_npc_by_vnum(10002)
-                if 0==v then
+                local v = find_npc_by_vnum(10002)
+                if 0 == v then
                 else
                     target.vid("__TARGET7__", v, gameforge.map_warp._180_select)
                 end
             elseif pc.get_empire() == 2 then -- = Chunjo
                 new_quest_lv7_HomeMapIndex = 21 -- = Joan
-                local v=find_npc_by_vnum(10004)
-                if 0==v then
+                local v = find_npc_by_vnum(10004)
+                if 0 == v then
                 else
                     target.vid("__TARGET7__", v, gameforge.map_warp._200_select)
                 end
             elseif pc.get_empire() == 3 then -- = Jinno
                 new_quest_lv7_HomeMapIndex = 41 -- = Pyungmoo
-                local v=find_npc_by_vnum(10006)
-                if 0==v then
+                local v = find_npc_by_vnum(10006)
+                if 0 == v then
                 else
                     target.vid("__TARGET7__", v, gameforge.map_warp._220_select)
                 end
@@ -452,8 +468,8 @@ quest new_quest_lv7 begin
             if pc.get_map_index() == new_quest_lv7_HomeMapIndex  then
                 target.delete("__TARGET7__")
                 --notice_multiline(gameforge.new_quest_lv7._129_say, notice)
-                local v=find_npc_by_vnum(20008)
-                if 0==v then
+                local v = find_npc_by_vnum(20008)
+                if 0 == v then
                 else
                     target.vid("__TARGET5__", v, gameforge.subquest_48._230_targetVid)
                 end
@@ -474,14 +490,14 @@ quest new_quest_lv7 begin
                 say(gameforge.new_quest_lv7._137_say)
             end			
         end		
-        
     end
+
     ------  invite ocatvio to the wedding ------------------------------------------------------------------------------------------------------
     state back_to_octavio begin
         when enter or login begin
             -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: no quest, no letter
-            local v=find_npc_by_vnum(20008)
-            if 0==v then
+            local v = find_npc_by_vnum(20008)
+            if 0 == v then
             else
                 target.vid("__TARGET5__", v, gameforge.new_quest_lv7._010_target)
             end
@@ -504,7 +520,6 @@ quest new_quest_lv7 begin
             say(gameforge.new_quest_lv7._129_say)
         end
         
-        
         when 20008.chat.gameforge.new_quest_lv7._020_say_title begin
             target.delete("__TARGET5__")
             say_title(gameforge.new_quest_lv7._020_say_title)
@@ -516,11 +531,11 @@ quest new_quest_lv7 begin
                 say(gameforge.new_quest_lv7._152_say)
 
                 -- random reward
-                local reward=new_quest_lv7.reward()
-                local reward_exp=new_quest_lv7.reward_exp()
+                local reward = new_quest_lv7.reward()
+                local reward_exp = new_quest_lv7.reward_exp()
 
-                say_reward(string.format(gameforge.new_quest_lv7._154_say_reward,reward_exp))
-                say_reward(string.format(gameforge.new_quest_lv7._155_say_reward,reward))
+                say_reward(string.format(gameforge.new_quest_lv7._154_say_reward, reward_exp))
+                say_reward(string.format(gameforge.new_quest_lv7._155_say_reward, reward))
                 
                 -- FIX: use the same values for the actual reward
                 pc.give_exp2(reward_exp)
@@ -528,89 +543,90 @@ quest new_quest_lv7 begin
 
                 pc.setqf("soup", 0) -- reset flavour flag after success
 
-                local reward_item="0"
+                local reward_item = "0"
                 local job = pc.get_job()
-                if job==0 then
-                    local r=number(1,10)
-                    if r==1 then
-                        reward_item="00013"
-                    elseif r==2 then
-                        reward_item="00023"
-                    elseif r==3 then
-                         reward_item="00033"
-                    elseif r==4 then
-                        reward_item="00043"
-                    elseif r==5 then
-                        reward_item="00053"
-                    elseif r==6 then
-                        reward_item="03003"
-                    elseif r==7 then
-                        reward_item="03013"
-                    elseif r==8 then
-                        reward_item="03023"
-                    elseif r==9 then
-                        reward_item="03033"
-                    elseif r==10 then
-                        reward_item="03043"
+                if job == 0 then
+                    local r = number(1,10)
+                    if r == 1 then
+                        reward_item = "00013"
+                    elseif r == 2 then
+                        reward_item = "00023"
+                    elseif r == 3 then
+                        reward_item = "00033"
+                    elseif r == 4 then
+                        reward_item = "00043"
+                    elseif r == 5 then
+                        reward_item = "00053"
+                    elseif r == 6 then
+                        reward_item = "03003"
+                    elseif r == 7 then
+                        reward_item = "03013"
+                    elseif r == 8 then
+                        reward_item = "03023"
+                    elseif r == 9 then
+                        reward_item = "03033"
+                    elseif r == 10 then
+                        reward_item = "03043"
                     end
-                elseif job==1 then
-                    local r=number(1,10)
-                    if r==1 then
-                        reward_item="01003"
-                    elseif r==2 then
-                        reward_item="04003"
-                    elseif r==3 then
-                        reward_item="01013"
-                    elseif r==4 then
-                        reward_item="04013"
-                    elseif r==5 then
-                        reward_item="01023"
-                    elseif r==6 then
-                        reward_item="02003"
-                    elseif r==7 then
-                        reward_item="02013"
-                    elseif r==8 then
-                        reward_item="02023"
-                    elseif r==9 then
-                        reward_item="02033"
-                    elseif r==10 then
-                        reward_item="02043"
+                elseif job == 1 then
+                    local r = number(1,10)
+                    if r == 1 then
+                        reward_item = "01003"
+                    elseif r == 2 then
+                        reward_item = "04003"
+                    elseif r == 3 then
+                        reward_item = "01013"
+                    elseif r == 4 then
+                        reward_item = "04013"
+                    elseif r == 5 then
+                        reward_item = "01023"
+                    elseif r == 6 then
+                        reward_item = "02003"
+                    elseif r == 7 then
+                        reward_item = "02013"
+                    elseif r == 8 then
+                        reward_item = "02023"
+                    elseif r == 9 then
+                        reward_item = "02033"
+                    elseif r == 10 then
+                        reward_item = "02043"
                     end
-                elseif job==2 then
-                    local r=number(1, 6)
-                    if r==1 then
-                        reward_item="00013"
-                    elseif r==2 then
-                        reward_item="00023"
-                    elseif r==3 then
-                        reward_item="00033"
-                    elseif r==4 then
-                        reward_item="00043"
-                    elseif r==5 then
-                        reward_item="00053"
-                    elseif r==6 then
-                        reward_item="00053"
+                elseif job == 2 then
+                    local r = number(1, 6)
+                    if r == 1 then
+                        reward_item = "00013"
+                    elseif r == 2 then
+                        reward_item = "00023"
+                    elseif r == 3 then
+                        reward_item = "00033"
+                    elseif r == 4 then
+                        reward_item = "00043"
+                    elseif r == 5 then
+                        reward_item = "00053"
+                    elseif r == 6 then
+                        reward_item = "00053"
                     end
-                elseif job==3 then
-                    local r=number(1, 8)
-                    if r==1 then
-                        reward_item="05003"
-                    elseif r==2 then
-                        reward_item="05013"
-                    elseif r==3 then
-                        reward_item="05023"
-                    elseif r==4 then
-                        reward_item="07003"
-                    elseif r==5 then
-                        reward_item="07013"
-                    elseif r==6 then
-                        reward_item="07023"
-                    elseif r==7 then
-                        reward_item="07033"
-                    elseif r==8 then
-                        reward_item="07043"
+                elseif job == 3 then
+                    local r = number(1, 8)
+                    if r == 1 then
+                        reward_item = "05003"
+                    elseif r == 2 then
+                        reward_item = "05013"
+                    elseif r == 3 then
+                        reward_item = "05023"
+                    elseif r == 4 then
+                        reward_item = "07003"
+                    elseif r == 5 then
+                        reward_item = "07013"
+                    elseif r == 6 then
+                        reward_item = "07023"
+                    elseif r == 7 then
+                        reward_item = "07033"
+                    elseif r == 8 then
+                        reward_item = "07043"
                     end
                 end
+
                 if reward_item != "0" then
                     wait()
                     say_reward(gameforge.new_quest_lv7._153_say_reward)
@@ -633,6 +649,7 @@ quest new_quest_lv7 begin
             return
         end
     end
+
     ------  complete ------------------------------------------------------------------------------------------------------
     state __COMPLETE__ begin
         when button or info begin

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -181,9 +181,7 @@ quest new_quest_lv7 begin
             q.set_title(gameforge.new_quest_lv7._020_say_title)
             
             -- FIX: if the player already has all flowers, go directly to return_oldwoman
-            if pc.count_item(ITEM_FLOWER_RED) >= NEED_RED
-                and pc.count_item(ITEM_FLOWER_ORANGE) >= NEED_ORANGE
-                and pc.count_item(ITEM_FLOWER_YELLOW) >= NEED_YELLOW then
+            if pc.count_item(ITEM_FLOWER_RED) >= NEED_RED and pc.count_item(ITEM_FLOWER_ORANGE) >= NEED_ORANGE and pc.count_item(ITEM_FLOWER_YELLOW) >= NEED_YELLOW then
                 q.done()
                 set_state(return_oldwoman)
                 return
@@ -202,9 +200,7 @@ quest new_quest_lv7 begin
                     --  EDIT Arne 18Sept09 moved q.done    Reason: removed quest from book
                     -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No arrow on old lady for flower return	
                     --notice_multiline(gameforge.new_quest_lv7._088_notice, notice)
-                    if pc.count_item(ITEM_FLOWER_YELLOW) == NEED_YELLOW
-                        and pc.count_item(ITEM_FLOWER_ORANGE) == NEED_ORANGE
-                        and pc.count_item(ITEM_FLOWER_RED) == NEED_RED then
+                    if pc.count_item(ITEM_FLOWER_YELLOW) == NEED_YELLOW and pc.count_item(ITEM_FLOWER_ORANGE) == NEED_ORANGE and pc.count_item(ITEM_FLOWER_RED) == NEED_RED then
                         return true
                     end
                 else
@@ -213,9 +209,7 @@ quest new_quest_lv7 begin
             end
 
             -- FIX: also check completion when there is no drop or flowers came from trade
-            if pc.count_item(ITEM_FLOWER_YELLOW) >= NEED_YELLOW
-                and pc.count_item(ITEM_FLOWER_ORANGE) >= NEED_ORANGE
-                and pc.count_item(ITEM_FLOWER_RED) >= NEED_RED then
+            if pc.count_item(ITEM_FLOWER_YELLOW) >= NEED_YELLOW and pc.count_item(ITEM_FLOWER_ORANGE) >= NEED_ORANGE and pc.count_item(ITEM_FLOWER_RED) >= NEED_RED then
                 return true
             end
         end
@@ -629,6 +623,7 @@ quest new_quest_lv7 begin
                     say_item_vnum(reward_item)
                     pc.give_item2(reward_item,1)
                 end
+                q.done()
                 set_state(__COMPLETE__)
             else
                 say(gameforge.new_quest_lv7._160_say)

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -1,4 +1,4 @@
-    quest new_quest_lv7 begin
+quest new_quest_lv7 begin
     state start begin
     -- Function declaration
         function reward()
@@ -25,7 +25,7 @@
             end
         end
         
-        when 20008.chat.gameforge.new_quest_lv7._020_say_title begin
+        when 20008.chat.gameforge.new_quest_lv7._020_say_title with pc.get_level() >= 7 begin
             target.delete("__TARGET__")
             local empire = pc.get_empire()
             say_title(gameforge.new_quest_lv7._011_say_title)  -- A Daughters Wedding
@@ -63,6 +63,7 @@
             end
         end
     end
+
     ---- ask altefrau what to do --------------------------------------------------------------------------------
     state ask_oldwoman begin
         function get_old_woman_map() 
@@ -90,8 +91,8 @@
             new_quest_lv7_mob1 = 173 -- kill a 173#Hungriger Alpha-Wolf
             new_quest_lv7_mob2 = 174 -- kill a 174#Hungriger Blauwolf
             new_quest_lv7_mob3 = 175 -- kill a 175#Hungriger Alpha-Blauwolf
-            -- Einige deser Mobs werden auch in der Level 7 Aufgabe verwendet, was dazu führt, 
-            -- dass diese dort nicht mehr hoch zählen wenn man sie tötet.
+            -- Einige deser Mobs werden auch in der Level 7 Aufgabe verwendet, was dazu fÃ¼hrt, 
+            -- dass diese dort nicht mehr hoch zÃ¤hlen wenn man sie tÃ¶tet.
             new_quest_lv7_drop1 = 30169 -- Blutrote Blume
             new_quest_lv7_drop2 = 30170 -- Orangefarbene Blume
             new_quest_lv7_drop3 = 30171 --  Duftende gelbe Blume
@@ -109,14 +110,15 @@
             end			
         end
         
-            -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No questbook button		
+        -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No questbook button		
         when button or info begin
             say_title(gameforge.new_quest_lv7._020_say_title) -- A Daughters Wedding
             say(gameforge.new_quest_lv7._041_say) -- goto old lady and ask her to help with the preperations
             say("")
-            say(string.format(gameforge.new_quest_lv7._042_say, get_map_name_by_number(1)))  -- where the old lady can be found
+            -- FIX: correct map name based on player's empire
+            say(string.format(gameforge.new_quest_lv7._042_say, get_map_name_by_number(new_quest_lv7.get_old_woman_map())))  -- where the old lady can be found
         end
-            --END EDIT
+        --END EDIT
         
         when 9006.chat.gameforge.new_quest_lv7._020_say_title begin
             target.delete("__TARGET2__")
@@ -125,7 +127,7 @@
         wait()
             say_title(gameforge.new_quest_lv7._012_say_title) -- yellow text headline
             say(gameforge.new_quest_lv7._052_say)
-            -- "vom Bräutigam an seine Liebste überreicht" versteht das unsere Zielgruppe?
+            -- "vom BrÃ¤utigam an seine Liebste Ã¼berreicht" versteht das unsere Zielgruppe?
         wait()	
             say(gameforge.new_quest_lv7._054_say)
             say_reward(string.format("%s x", new_quest_lv7_AmountNeed1))
@@ -172,7 +174,15 @@
             send_letter(gameforge.new_quest_lv7._020_say_title)	
             q.start()
             q.set_title(gameforge.new_quest_lv7._020_say_title)
-                
+            
+            -- FIX: if the player already has all flowers, go directly to return_oldwoman
+            if pc.count_item(new_quest_lv7_drop1) >= new_quest_lv7_AmountNeed1
+               and pc.count_item(new_quest_lv7_drop2) >= new_quest_lv7_AmountNeed2
+               and pc.count_item(new_quest_lv7_drop3) >= new_quest_lv7_AmountNeed3 then
+                q.done()
+                set_state(return_oldwoman)
+                return
+            end                
         end
         --END EDIT		
         
@@ -193,6 +203,11 @@
                 else
             notice_multiline(gameforge.new_quest_lv7._082_say, notice)
         end
+            end
+
+            -- FIX: also check completion when there is no drop or flowers came from trade
+            if (pc.count_item(new_quest_lv7_drop3) >= new_quest_lv7_AmountNeed3 and pc.count_item(new_quest_lv7_drop2) >= new_quest_lv7_AmountNeed2 and pc.count_item(new_quest_lv7_drop1) >= new_quest_lv7_AmountNeed1) then
+                return true
             end
         end
         -------------- Blutrote Blume ------------------------------------------------------
@@ -264,7 +279,8 @@
             say_title(gameforge.new_quest_lv7._020_say_title)
             say(gameforge.new_quest_lv7._091_say) -- success return to old lady
             say("")
-            say(string.format(gameforge.new_quest_lv7._042_say, get_map_name_by_number(1)))
+            -- FIX: correct map name (same logic as in ask_oldwoman)
+            say(string.format(gameforge.new_quest_lv7._042_say, get_map_name_by_number(new_quest_lv7.get_old_woman_map())))
         end
     --END EDIT
 
@@ -274,9 +290,10 @@
             say_title(gameforge.new_quest_lv7._012_say_title)
             if (pc.count_item(new_quest_lv7_drop1) < new_quest_lv7_AmountNeed1 or pc.count_item(new_quest_lv7_drop2) < new_quest_lv7_AmountNeed2 or pc.count_item(new_quest_lv7_drop3) < new_quest_lv7_AmountNeed3) then
                 say(gameforge.new_quest_lv7._110_say)
-                say_reward(string.format(gameforge.new_quest_lv7._085_say_reward, new_quest_lv7_AmountNeed1 - pc.count_item(new_quest_lv7_drop1)))
-                say_reward(string.format(gameforge.new_quest_lv7._086_say_reward, new_quest_lv7_AmountNeed2 - pc.count_item(new_quest_lv7_drop2)))
-                say_reward(string.format(gameforge.new_quest_lv7._087_say_reward, new_quest_lv7_AmountNeed3 - pc.count_item(new_quest_lv7_drop3)))
+                -- FIX: avoid negative numbers if player has more flowers than needed
+                say_reward(string.format(gameforge.new_quest_lv7._085_say_reward, math.max(0, new_quest_lv7_AmountNeed1 - pc.count_item(new_quest_lv7_drop1))))
+                say_reward(string.format(gameforge.new_quest_lv7._086_say_reward, math.max(0, new_quest_lv7_AmountNeed2 - pc.count_item(new_quest_lv7_drop2))))
+                say_reward(string.format(gameforge.new_quest_lv7._087_say_reward, math.max(0, new_quest_lv7_AmountNeed3 - pc.count_item(new_quest_lv7_drop3))))
                 say(gameforge.new_quest_lv7._081_say)
                 set_state(collect_flowers)
             else
@@ -466,7 +483,13 @@
             q.start()
             q.set_title(gameforge.new_quest_lv7._020_say_title)
             -- END EDIT
-            soup = false
+
+            -- FIX: keep soup flag persistent via quest flag
+            if pc.getqf("soup") == 1 then
+                soup = true
+            else
+                soup = false
+            end
         end
         
         when button or info begin
@@ -492,8 +515,11 @@
                 say_reward(string.format(gameforge.new_quest_lv7._154_say_reward,reward_exp))
                 say_reward(string.format(gameforge.new_quest_lv7._155_say_reward,reward))
                 
-                pc.give_exp2(new_quest_lv7.reward_exp())
-                pc.change_money(new_quest_lv7.reward())
+                -- FIX: use the same values for the actual reward
+                pc.give_exp2(reward_exp)
+                pc.change_money(reward)
+
+                pc.setqf("soup", 0) -- reset flavour flag after success
 
                 local reward_item="0"
                 if pc.job==0 then
@@ -588,6 +614,7 @@
                 say(gameforge.new_quest_lv7._160_say)
                 say(gameforge.new_quest_lv7._165_say)
                 soup = true
+                pc.setqf("soup", 1) -- FIX: remember that player talked to the wrong Octavio
             end
         end
     end

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -1,3 +1,20 @@
+-- Flower items and bouquet
+define ITEM_FLOWER_RED     30169  -- Red Flower
+define ITEM_FLOWER_ORANGE  30170  -- Orange Flower
+define ITEM_FLOWER_YELLOW  30171  -- Yellow Flower
+define ITEM_BOUQUET        30172  -- Bouquet
+
+-- Required amounts
+define NEED_RED            1
+define NEED_ORANGE         1
+define NEED_YELLOW         1
+
+-- Drop chances (percent)
+define DROP_RED            45
+define DROP_ORANGE         30
+define DROP_YELLOW         15
+
+
 quest new_quest_lv7 begin
     state start begin
         -- Function declaration
@@ -89,17 +106,11 @@ quest new_quest_lv7 begin
         end
                 
         when enter or login begin
-            new_quest_lv7_AmountNeed1 = 1
-            new_quest_lv7_AmountNeed2 = 1
-            new_quest_lv7_AmountNeed3 = 1
             new_quest_lv7_mob1 = 173 -- kill a 173#Hungriger Alpha-Wolf
             new_quest_lv7_mob2 = 174 -- kill a 174#Hungriger Blauwolf
             new_quest_lv7_mob3 = 175 -- kill a 175#Hungriger Alpha-Blauwolf
             -- Einige deser Mobs werden auch in der Level 7 Aufgabe verwendet, was dazu führt, 
             -- dass diese dort nicht mehr hoch zählen wenn man sie tötet.
-            new_quest_lv7_drop1 = 30169 -- Blutrote Blume
-            new_quest_lv7_drop2 = 30170 -- Orangefarbene Blume
-            new_quest_lv7_drop3 = 30171 --  Duftende gelbe Blume
 
             -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No quest letter, no questbook entry
             send_letter(gameforge.new_quest_lv7._020_say_title)  -- A Daughters Wedding
@@ -136,20 +147,20 @@ quest new_quest_lv7 begin
             -- "vom Bräutigam an seine Liebste überreicht" versteht das unsere Zielgruppe?
             wait()	
             say(gameforge.new_quest_lv7._054_say)
-            say_reward(string.format("%s x", new_quest_lv7_AmountNeed1))
-            say_item_vnum(new_quest_lv7_drop1) -- icon of item
+            say_reward(string.format("%s x", NEED_RED))
+            say_item_vnum(ITEM_FLOWER_RED) -- icon of item
             say_reward(gameforge.new_quest_lv7._055_say)
             say(mob_name(new_quest_lv7_mob1))
             wait()
             say(gameforge.new_quest_lv7._056_say)
-            say_reward(string.format("%s x", new_quest_lv7_AmountNeed2))
-            say_item_vnum(new_quest_lv7_drop2) -- icon of item
+            say_reward(string.format("%s x", NEED_ORANGE))
+            say_item_vnum(ITEM_FLOWER_ORANGE) -- icon of item
             say_reward(gameforge.new_quest_lv7._055_say)
             say(mob_name(new_quest_lv7_mob2))
             wait()
             say(gameforge.new_quest_lv7._056_say)
-            say_reward(string.format("%s x", new_quest_lv7_AmountNeed3))
-            say_item_vnum(new_quest_lv7_drop3) -- icon of item
+            say_reward(string.format("%s x", NEED_YELLOW))
+            say_item_vnum(ITEM_FLOWER_YELLOW) -- icon of item
             say_reward(gameforge.new_quest_lv7._055_say )
             say(mob_name(new_quest_lv7_mob3))
             wait()
@@ -165,23 +176,14 @@ quest new_quest_lv7 begin
     state collect_flowers begin
         -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No letter, questbook entry, button						
         when enter or login begin	
-            new_quest_lv7_AmountNeed1 = 1
-            new_quest_lv7_AmountNeed2 = 1
-            new_quest_lv7_AmountNeed3 = 1
-            new_quest_lv7_dropProb1 = 45
-            new_quest_lv7_dropProb2 = 30
-            new_quest_lv7_dropProb3 = 15
-            new_quest_lv7_drop1 = 30169 -- Blutrote Blume
-            new_quest_lv7_drop2 = 30170 -- Orangefarbene Blume
-            new_quest_lv7_drop3 = 30171 --  Duftende gelbe Blume
             send_letter(gameforge.new_quest_lv7._020_say_title)	
             q.start()
             q.set_title(gameforge.new_quest_lv7._020_say_title)
             
             -- FIX: if the player already has all flowers, go directly to return_oldwoman
-            if pc.count_item(new_quest_lv7_drop1) >= new_quest_lv7_AmountNeed1
-                and pc.count_item(new_quest_lv7_drop2) >= new_quest_lv7_AmountNeed2
-                and pc.count_item(new_quest_lv7_drop3) >= new_quest_lv7_AmountNeed3 then
+            if pc.count_item(ITEM_FLOWER_RED) >= NEED_RED
+                and pc.count_item(ITEM_FLOWER_ORANGE) >= NEED_ORANGE
+                and pc.count_item(ITEM_FLOWER_YELLOW) >= NEED_YELLOW then
                 q.done()
                 set_state(return_oldwoman)
                 return
@@ -200,9 +202,9 @@ quest new_quest_lv7 begin
                     --  EDIT Arne 18Sept09 moved q.done    Reason: removed quest from book
                     -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No arrow on old lady for flower return	
                     --notice_multiline(gameforge.new_quest_lv7._088_notice, notice)
-                    if pc.count_item(new_quest_lv7_drop3) == new_quest_lv7_AmountNeed3
-                        and pc.count_item(new_quest_lv7_drop2) == new_quest_lv7_AmountNeed2
-                        and pc.count_item(new_quest_lv7_drop1) == new_quest_lv7_AmountNeed1 then
+                    if pc.count_item(ITEM_FLOWER_YELLOW) == NEED_YELLOW
+                        and pc.count_item(ITEM_FLOWER_ORANGE) == NEED_ORANGE
+                        and pc.count_item(ITEM_FLOWER_RED) == NEED_RED then
                         return true
                     end
                 else
@@ -211,9 +213,9 @@ quest new_quest_lv7 begin
             end
 
             -- FIX: also check completion when there is no drop or flowers came from trade
-            if pc.count_item(new_quest_lv7_drop3) >= new_quest_lv7_AmountNeed3
-                and pc.count_item(new_quest_lv7_drop2) >= new_quest_lv7_AmountNeed2
-                and pc.count_item(new_quest_lv7_drop1) >= new_quest_lv7_AmountNeed1 then
+            if pc.count_item(ITEM_FLOWER_YELLOW) >= NEED_YELLOW
+                and pc.count_item(ITEM_FLOWER_ORANGE) >= NEED_ORANGE
+                and pc.count_item(ITEM_FLOWER_RED) >= NEED_RED then
                 return true
             end
         end
@@ -221,7 +223,7 @@ quest new_quest_lv7 begin
         -------------- Blutrote Blume ------------------------------------------------------
         -- kill a 173#Hungriger Alpha-Wolf
         when 173.kill begin
-            if new_quest_lv7.when_one_killed(new_quest_lv7_AmountNeed1, new_quest_lv7_dropProb1, new_quest_lv7_drop1) then
+            if new_quest_lv7.when_one_killed(NEED_RED, DROP_RED, ITEM_FLOWER_RED) then
                 q.done()
                 set_state(return_oldwoman)
             end
@@ -230,7 +232,7 @@ quest new_quest_lv7 begin
         -------------- Orangefarbene Blume ------------------------------------------------------
         -- kill a 174#Hungriger Blauwolf
         when 174.kill begin
-            if new_quest_lv7.when_one_killed(new_quest_lv7_AmountNeed2, new_quest_lv7_dropProb2, new_quest_lv7_drop2) then 
+            if new_quest_lv7.when_one_killed(NEED_ORANGE, DROP_ORANGE, ITEM_FLOWER_ORANGE) then 
                 q.done()
                 set_state(return_oldwoman)
             end
@@ -239,7 +241,7 @@ quest new_quest_lv7 begin
         -------------- Duftende gelbe Blume ------------------------------------------------------
         -- kill a 175#Hungriger Alpha-Blauwolf
         when 175.kill begin		
-            if new_quest_lv7.when_one_killed(new_quest_lv7_AmountNeed3, new_quest_lv7_dropProb3, new_quest_lv7_drop3) then
+            if new_quest_lv7.when_one_killed(NEED_YELLOW, DROP_YELLOW, ITEM_FLOWER_YELLOW) then
                 q.done()
                 set_state(return_oldwoman)
             end
@@ -250,14 +252,14 @@ quest new_quest_lv7 begin
         when button or info begin
             say_title(gameforge.new_quest_lv7._020_say_title)
             say(gameforge.new_quest_lv7._092_say) -- collect flowers for the Bouquet
-            if pc.count_item(new_quest_lv7_drop1) < new_quest_lv7_AmountNeed1 then
-                say_reward(string.format(gameforge.new_quest_lv7._085_1_say_reward, new_quest_lv7_AmountNeed1 - pc.count_item(new_quest_lv7_drop1))) -- number of red flowers missing
+            if pc.count_item(ITEM_FLOWER_RED) < NEED_RED then
+                say_reward(string.format(gameforge.new_quest_lv7._085_1_say_reward, NEED_RED - pc.count_item(ITEM_FLOWER_RED))) -- number of red flowers missing
             end
-            if pc.count_item(new_quest_lv7_drop2) < new_quest_lv7_AmountNeed2 then
-                say_reward(string.format(gameforge.new_quest_lv7._085_2_say_reward, new_quest_lv7_AmountNeed2 - pc.count_item(new_quest_lv7_drop2))) -- number of orange flowers missing
+            if pc.count_item(ITEM_FLOWER_ORANGE) < NEED_ORANGE then
+                say_reward(string.format(gameforge.new_quest_lv7._085_2_say_reward, NEED_ORANGE - pc.count_item(ITEM_FLOWER_ORANGE))) -- number of orange flowers missing
             end
-            if pc.count_item(new_quest_lv7_drop3) < new_quest_lv7_AmountNeed3 then
-                say_reward(string.format(gameforge.new_quest_lv7._085_3_say_reward, new_quest_lv7_AmountNeed3 - pc.count_item(new_quest_lv7_drop3))) -- number of yellow flowers missing
+            if pc.count_item(ITEM_FLOWER_YELLOW) < NEED_YELLOW then
+                say_reward(string.format(gameforge.new_quest_lv7._085_3_say_reward, NEED_YELLOW - pc.count_item(ITEM_FLOWER_YELLOW))) -- number of yellow flowers missing
             end
         end
     end
@@ -265,12 +267,6 @@ quest new_quest_lv7 begin
 
     state return_oldwoman begin -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, state needed to set up quest		
         when enter or login begin
-            new_quest_lv7_AmountNeed1 = 1
-            new_quest_lv7_AmountNeed2 = 1
-            new_quest_lv7_AmountNeed3 = 1
-            new_quest_lv7_drop1 = 30169 -- Blutrote Blume
-            new_quest_lv7_drop2 = 30170 -- Orangefarbene Blume
-            new_quest_lv7_drop3 = 30171 --  Duftende gelbe Blume
             local v = find_npc_by_vnum(9006)
             send_letter(gameforge.new_quest_lv7._020_say_title)
             q.start()
@@ -294,21 +290,21 @@ quest new_quest_lv7 begin
         when 9006.chat.gameforge.new_quest_lv7._020_say_title begin
             target.delete("__TARGET6__")
             say_title(gameforge.new_quest_lv7._012_say_title)
-            if pc.count_item(new_quest_lv7_drop1) < new_quest_lv7_AmountNeed1
-                or pc.count_item(new_quest_lv7_drop2) < new_quest_lv7_AmountNeed2
-                or pc.count_item(new_quest_lv7_drop3) < new_quest_lv7_AmountNeed3 then
+            if pc.count_item(ITEM_FLOWER_RED) < NEED_RED
+                or pc.count_item(ITEM_FLOWER_ORANGE) < NEED_ORANGE
+                or pc.count_item(ITEM_FLOWER_YELLOW) < NEED_YELLOW then
                 say(gameforge.new_quest_lv7._110_say)
                 -- FIX: avoid negative numbers if player has more flowers than needed
-                say_reward(string.format(gameforge.new_quest_lv7._085_say_reward, math.max(0, new_quest_lv7_AmountNeed1 - pc.count_item(new_quest_lv7_drop1))))
-                say_reward(string.format(gameforge.new_quest_lv7._086_say_reward, math.max(0, new_quest_lv7_AmountNeed2 - pc.count_item(new_quest_lv7_drop2))))
-                say_reward(string.format(gameforge.new_quest_lv7._087_say_reward, math.max(0, new_quest_lv7_AmountNeed3 - pc.count_item(new_quest_lv7_drop3))))
+                say_reward(string.format(gameforge.new_quest_lv7._085_say_reward, math.max(0, NEED_RED - pc.count_item(ITEM_FLOWER_RED))))
+                say_reward(string.format(gameforge.new_quest_lv7._086_say_reward, math.max(0, NEED_ORANGE - pc.count_item(ITEM_FLOWER_ORANGE))))
+                say_reward(string.format(gameforge.new_quest_lv7._087_say_reward, math.max(0, NEED_YELLOW - pc.count_item(ITEM_FLOWER_YELLOW))))
                 say(gameforge.new_quest_lv7._081_say)
                 set_state(collect_flowers)
             else
-                pc.remove_item(30169, 1)
-                pc.remove_item(30170, 1)
-                pc.remove_item(30171, 1)
-                pc.give_item2(30172) -- flowers
+                pc.remove_item(ITEM_FLOWER_RED, NEED_RED)
+                pc.remove_item(ITEM_FLOWER_ORANGE, NEED_ORANGE)
+                pc.remove_item(ITEM_FLOWER_YELLOW, NEED_YELLOW)
+                pc.give_item2(ITEM_BOUQUET) -- flowers
                 -- game.drop_item(30169, 1)
                 say(gameforge.new_quest_lv7._115_say)
                 -- hier fehlt info wie man in das reich kommt
@@ -405,10 +401,10 @@ quest new_quest_lv7 begin
         end
         
         when 9006.chat.gameforge.new_quest_lv7._020_say_title with pc.get_map_index() == new_quest_lv7_DestMapIndex begin
-            if pc.count_item(30172) >= 1 then -- has flowers in inventory
+            if pc.count_item(ITEM_BOUQUET) >= 1 then -- has flowers in inventory
                 target.delete("__TARGET3__")
                 say_title(gameforge.new_quest_lv7._020_say_title) -- yellow
-                pc.remove_item(30172, pc.count_item(30172))
+                pc.remove_item(ITEM_BOUQUET, pc.count_item(ITEM_BOUQUET))
                 say_title(pc.get_name())
                 say(gameforge.new_quest_lv7._140_say)
                 say_title(gameforge.new_quest_lv7._012_say_title)

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -147,10 +147,6 @@ quest new_quest_lv7 begin
             say_item_vnum(new_quest_lv7_drop3) -- icon of item
             say_reward(gameforge.new_quest_lv7._055_say )
             say(mob_name(new_quest_lv7_mob3))
-            --set flags:
-            pc.setqf("collect_count_1",0) --Current number of items
-            pc.setqf("collect_count_2",0) --Current number of items
-            pc.setqf("collect_count_3",0) --Current number of items
         wait()
             say_title(gameforge.new_quest_lv7._012_say_title)
             say(gameforge.new_quest_lv7._060_say)

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -284,9 +284,7 @@ quest new_quest_lv7 begin
         when 9006.chat.gameforge.new_quest_lv7._020_say_title begin
             target.delete("__TARGET6__")
             say_title(gameforge.new_quest_lv7._012_say_title)
-            if pc.count_item(ITEM_FLOWER_RED) < NEED_RED
-                or pc.count_item(ITEM_FLOWER_ORANGE) < NEED_ORANGE
-                or pc.count_item(ITEM_FLOWER_YELLOW) < NEED_YELLOW then
+            if pc.count_item(ITEM_FLOWER_RED) < NEED_RED or pc.count_item(ITEM_FLOWER_ORANGE) < NEED_ORANGE or pc.count_item(ITEM_FLOWER_YELLOW) < NEED_YELLOW then
                 say(gameforge.new_quest_lv7._110_say)
                 -- FIX: avoid negative numbers if player has more flowers than needed
                 say_reward(string.format(gameforge.new_quest_lv7._085_say_reward, math.max(0, NEED_RED - pc.count_item(ITEM_FLOWER_RED))))

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -45,6 +45,7 @@ quest new_quest_lv7 begin
             say(gameforge.new_quest_lv7._031_say) -- Go to the Old Lady and ask her to help with the preperations 
             local doquest = select(gameforge.subquest_06._40_select, gameforge.subquest_12._50_select, gameforge.new_quest_lv75._290_2_select)
             if doquest == 1 then
+                pc.setqf("soup", 0)  -- hard reset flavour flag at quest start
                 set_state(ask_oldwoman) -- Quest approved
             elseif doquest == 3 then -- abort permantenly
                 say(gameforge.subquest_06._60_say)

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -529,7 +529,8 @@ quest new_quest_lv7 begin
                 pc.setqf("soup", 0) -- reset flavour flag after success
 
                 local reward_item="0"
-                if pc.job==0 then
+                local job = pc.get_job()
+                if job==0 then
                     local r=number(1,10)
                     if r==1 then
                         reward_item="00013"
@@ -552,7 +553,7 @@ quest new_quest_lv7 begin
                     elseif r==10 then
                         reward_item="03043"
                     end
-                elseif pc.job==1 then
+                elseif job==1 then
                     local r=number(1,10)
                     if r==1 then
                         reward_item="01003"
@@ -573,9 +574,9 @@ quest new_quest_lv7 begin
                     elseif r==9 then
                         reward_item="02033"
                     elseif r==10 then
-                        reward_item="2043"
+                        reward_item="02043"
                     end
-                elseif pc.job==2 then
+                elseif job==2 then
                     local r=number(1, 6)
                     if r==1 then
                         reward_item="00013"
@@ -590,7 +591,7 @@ quest new_quest_lv7 begin
                     elseif r==6 then
                         reward_item="00053"
                     end
-                elseif pc.job==3 then
+                elseif job==3 then
                     local r=number(1, 8)
                     if r==1 then
                         reward_item="05003"

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -381,9 +381,19 @@ quest new_quest_lv7 begin
             send_letter(gameforge.new_quest_lv7._020_say_title)
             q.start()
             q.set_title(gameforge.new_quest_lv7._020_say_title)
+
+            -- FIX: recompute destination map index to ensure correct map for the sister
+            new_quest_lv7_DestMapIndex = 99
+            if pc.get_empire() == 1 then -- = Shinsoo
+                new_quest_lv7_DestMapIndex = 3  -- = Yayang
+            elseif pc.get_empire() == 2 then -- = Chunjo
+                new_quest_lv7_DestMapIndex = 23 -- = Bokjung
+            elseif pc.get_empire() == 3 then -- = Jinno
+                new_quest_lv7_DestMapIndex = 43 -- = Bakra
+            end
         end
         
-        when 9006.chat.gameforge.new_quest_lv7._020_say_title begin
+        when 9006.chat.gameforge.new_quest_lv7._020_say_title with pc.get_map_index() == new_quest_lv7_DestMapIndex begin
             if pc.count_item(30172) >= 1 then -- has flowers in inventory
                 target.delete("__TARGET3__")
                 say_title(gameforge.new_quest_lv7._020_say_title) -- yellow

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -188,7 +188,7 @@ quest new_quest_lv7 begin
         -- itemicon vnum of flower used for icon 
         function when_one_killed(neededAmount, dropProb, itemIcon)
             if pc.count_item(itemIcon) < neededAmount then
-        local drop=math.random(1,100)
+        local drop=number(1,100)
                 if drop <= dropProb then -- probability if s.th. drops
                     pc.give_item2(itemIcon) -- icon of item by vnum - Blutrote Blume
                     --  EDIT Arne 18Sept09 moved q.done    Reason: removed quest from book

--- a/share/locale/english/quest/new_quest_lv7.quest
+++ b/share/locale/english/quest/new_quest_lv7.quest
@@ -193,12 +193,12 @@ quest new_quest_lv7 begin
                     pc.give_item2(itemIcon) -- icon of item by vnum - Blutrote Blume
                     --  EDIT Arne 18Sept09 moved q.done    Reason: removed quest from book
                     -- BEGIN EDIT added by Arne 18Sept09, according to Mantis 0026063, REASON: No arrow on old lady for flower return	
-                    notice_multiline(gameforge.new_quest_lv7._088_notice, notice)
+                    --notice_multiline(gameforge.new_quest_lv7._088_notice, notice)
                     if (pc.count_item(new_quest_lv7_drop3) == new_quest_lv7_AmountNeed3 and pc.count_item(new_quest_lv7_drop2) == new_quest_lv7_AmountNeed2 and pc.count_item(new_quest_lv7_drop1) == new_quest_lv7_AmountNeed1) then
             return true
             end
                 else
-            notice_multiline(gameforge.new_quest_lv7._082_say, notice)
+            --notice_multiline(gameforge.new_quest_lv7._082_say, notice)
         end
             end
 
@@ -349,7 +349,7 @@ quest new_quest_lv7 begin
             end
             if pc.get_map_index() == new_quest_lv7_DestMapIndex  then
                 target.delete("__TARGET7__")
-                notice_multiline(gameforge.new_quest_lv7._125_notice, notice)
+                --notice_multiline(gameforge.new_quest_lv7._125_notice, notice)
                 local v=find_npc_by_vnum(9006)
                 if 0==v then
                 else
@@ -451,7 +451,7 @@ quest new_quest_lv7 begin
             end
             if pc.get_map_index() == new_quest_lv7_HomeMapIndex  then
                 target.delete("__TARGET7__")
-                notice_multiline(gameforge.new_quest_lv7._129_say, notice)
+                --notice_multiline(gameforge.new_quest_lv7._129_say, notice)
                 local v=find_npc_by_vnum(20008)
                 if 0==v then
                 else


### PR DESCRIPTION
- Enforce minimum level 7 when starting the quest dialog with Octavio
- Use get_old_woman_map() to show the correct village name in quest info (ask_oldwoman and return_oldwoman states) instead of hardcoding map 1
- Ensure quest progresses correctly when the player already has all required flowers (both on state enter and on wolf kills)
- Extend completion check in when_one_killed() so flower sets obtained via trade or previous drops still advance the quest
- Prevent negative “missing flowers” values when the player owns more items than required
- Make “soup” flavour flag persistent using quest flags (pc.setqf/pc.getqf) so related dialogue is preserved across relogs
- Make EXP/Yang reward text match the actual reward granted by reusing the same random values instead of recalculating them
