### PR TITLE
Fix define replacement when identifier appears at end of line

### DIFF
--- a/share/locale/english/quest/pre_qc.py
+++ b/share/locale/english/quest/pre_qc.py
@@ -104,7 +104,7 @@ def Replace(lines, parameter_table, keys):
 			else:
 				tokens = my_split_with_seps(
 					s,
-					["\t", ",", " ", "=", "[", "]", "-", "<", ">", "~", "!", ".", "(", ")"],
+					["\t", ",", " ", "=", "[", "]", "-", "<", ">", "~", "!", ".", "(", ")", "\r", "\n"],
 				)
 				for key in keys:
 					try:


### PR DESCRIPTION
## Summary

Fix an issue in "pre_qc.py" where "define"-d identifiers were not replaced
when they appeared at the end of a line, immediately followed by a newline
character.

Example that previously failed:

```
define ALFONSO 123

if 123 == ALFONSO
   or 124 == ALFONSO then
```
   
In this case, the first ALFONSO was not replaced, while the second one was.


Thanks a lot to @SuntrustDev for this fix! 👍 