### PR TITLE
Remove unused / stale cube opening quests and interactions

### DIFF
--- a/share/locale/english/quest/cube.quest
+++ b/share/locale/english/quest/cube.quest
@@ -26,23 +26,6 @@ quest cube begin
             command("cube open")
         end
 
-        when 20018.chat.gameforge.cube._060_npcChat with pc.level >= 15 begin
-            setskin(NOWINDOW)
-            command("cube make all")
-        end
-
-
-        when 20017.chat.gameforge.cube._060_npcChat with pc.level >= 30 begin
-            setskin(NOWINDOW)
-            command("cube make all")
-        end
-
-
-        when 20022.chat.gameforge.cube._060_npcChat with pc.level >=45 begin
-            setskin(NOWINDOW)
-            command("cube make all")
-        end
-
         when 20383.chat.gameforge.cube._30_npcChat with pc.level >=90 begin
             setskin(NOWINDOW)
             command("cube open")

--- a/share/locale/english/quest/cube_opener_list.quest
+++ b/share/locale/english/quest/cube_opener_list.quest
@@ -70,16 +70,6 @@ quest cube_opener_list begin
 
 			end
 		end
-		
-        when
-            20383.take or
-            20018.take or
-            20017.take or
-            20015.take
-        begin
-
-            command("cube open")
-        end
     end
 end
 


### PR DESCRIPTION
Two main things:
- Remove stale "Produce all potions" NPC menu item
- Remove not-working drag-to-open cube